### PR TITLE
Add general ledger journal entry lines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2.1.1
+      - uses: actions/setup-python@v2.1.4
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v2

--- a/src/tap_intacct/client.py
+++ b/src/tap_intacct/client.py
@@ -318,10 +318,10 @@ class SageIntacctSDK:
                 intacct_object_type
             ]
             # When only 1 object is found, Intacct returns a dict, otherwise it returns a list of dicts.
-            if isinstance(intacct_objects, list):
-                total_intacct_objects = total_intacct_objects + intacct_objects
-            else:
-                total_intacct_objects = [intacct_objects]
+            if isinstance(intacct_objects, dict):
+                intacct_objects = [intacct_objects]
+
+            total_intacct_objects = total_intacct_objects + intacct_objects
 
             offset = offset + pagesize
         return total_intacct_objects

--- a/src/tap_intacct/const.py
+++ b/src/tap_intacct/const.py
@@ -8,10 +8,11 @@ REQUIRED_CONFIG_KEYS = [
 
 KEY_PROPERTIES = {
     'accounts_payable_bills': ["RECORDNO"],
-    'accounts_payable_vendors': ["RECORDNO"],
+    'accounts_payable_vendors': ["VENDORID"],
     'general_ledger_accounts': ['RECORDNO'],
     'general_ledger_details': ["RECORDNO"],
     'general_ledger_journal_entries': ["RECORDNO"],
+    'general_ledger_journal_entry_lines': ["RECORDNO"],
     'projects': ["RECORDNO"],
 }
 
@@ -22,6 +23,7 @@ INTACCT_OBJECTS = {
     "general_ledger_accounts": "GLACCOUNT",
     "general_ledger_details": "GLDETAIL",
     "general_ledger_journal_entries": "GLBATCH",
+    "general_ledger_journal_entry_lines": "GLENTRY",
     "projects": "PROJECT",
 }
 

--- a/src/tap_intacct/schemas/general_ledger_journal_entry_lines.json
+++ b/src/tap_intacct/schemas/general_ledger_journal_entry_lines.json
@@ -1,0 +1,99 @@
+{
+	"type": "object",
+	"properties": {
+		"RECORDNO": {
+			"type": ["null", "string"]
+		},
+		"BATCHNO": {
+			"type": ["null", "string"]
+		},
+		"USERNO": {
+			"type": ["null", "string"]
+		},
+		"LINE_NO": {
+			"type": ["null", "string"]
+		},
+		"TR_TYPE": {
+			"type": ["null", "string"]
+		},
+		"ENTRY_DATE": {
+            "type": ["null", "string"],
+            "format": "date"
+        },
+		"AMOUNT": {
+            "type": ["null", "number"]
+        },
+		"TRX_AMOUNT": {
+            "type": ["null", "number"]
+        },
+		"BATCHTITLE": {
+			"type": ["null", "string"]
+		},
+		"ACCOUNTNO": {
+			"type": ["null", "string"]
+		},
+		"ACCOUNTTITLE": {
+			"type": ["null", "string"]
+		},
+		"DEPARTMENT": {
+			"type": ["null", "string"]
+		},
+		"DEPARTMENTTITLE": {
+			"type": ["null", "string"]
+		},
+		"LOCATION": {
+			"type": ["null", "string"]
+		},
+		"LOCATIONNAME": {
+			"type": ["null", "string"]
+		},
+		"BASECURR": {
+			"type": ["null", "string"]
+		},
+		"CURRENCY": {
+			"type": ["null", "string"]
+		},
+		"CLEARED": {
+            "type": ["null", "boolean"]
+        },
+		"ADJ": {
+            "type": ["null", "boolean"]
+        },
+		"EXCH_RATE_DATE": {
+            "type": ["null", "string"],
+            "format": "date"
+        },
+		"EXCHANGE_RATE": {
+            "type": ["null", "number"]
+        },
+		"WHENCREATED": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+		"WHENMODIFIED": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+		"CREATEDBY": {
+			"type": ["null", "string"]
+		},
+		"MODIFIEDBY": {
+			"type": ["null", "string"]
+		},
+		"STATE": {
+			"type": ["null", "string"]
+		},
+		"BILLABLE": {
+            "type": ["null", "boolean"]
+        },
+		"MANUAL_VAT_AMOUNT": {
+            "type": ["null", "boolean"]
+        },
+		"CLASSID": {
+			"type": ["null", "string"]
+		},
+		"CLASSNAME": {
+			"type": ["null", "string"]
+		}
+	}
+}


### PR DESCRIPTION
## Why are we changing this?

- General ledger journal entry lines is required to get reporting in Looker in a state that matches GL Reports from Intacct directly.

## What has changed?

- Added schema for General ledger journal entry lines (GLENTRY endpoint)
- Changed logic for when a single dict is returned from API to prevent error where the last page of results only has 1 object returned.

## How to test it and expected results?

- Tested and confirmed with Snowflake table raw.intacct.tmp__general_ledger_journal_entry_lines
![Screenshot 2020-11-19 at 13 55 58](https://user-images.githubusercontent.com/16795226/99675313-f9c2e280-2a6e-11eb-9145-2df7d3e0365f.png)

